### PR TITLE
Events Searchable and have date format changed to be easier to work with

### DIFF
--- a/app.py
+++ b/app.py
@@ -109,14 +109,27 @@ def logout():
     return redirect(url_for("home"))
 
 
-@app.route("/get_events")
+@app.route("/get_events", methods=["GET", "POST"])
 def get_events():
     """
         Get all events in the database to
         display on 'Events' page.
     """
-    events = mongo.db.events.find()
-    events = events.sort("event_date")
+    if request.method == "POST":
+        #allows text search to happen, might just need to be moved to when items are added?
+        mongo.db.events.create_index(
+            [
+            ("event_name", "text"),
+            ("event_description", "text"),
+            ("event_place", "text"),
+            ])
+        events = mongo.db.events.find( { "$text": { "$search": request.form["query"] } } )
+    else:
+        events = mongo.db.events.find()
+    
+    events = events.sort("event_date") 
+    
+    #allows page to know if an event is in the past, and change display if so
     now = datetime.datetime.now()
     return render_template("events.html", events=events, now=now)
 

--- a/app.py
+++ b/app.py
@@ -8,6 +8,8 @@ from werkzeug.security import generate_password_hash, check_password_hash
 if os.path.exists("env.py"):
     import env # nqa
 
+import dateutil.parser, datetime
+
 
 # Initialize app
 app = Flask(__name__)
@@ -114,7 +116,9 @@ def get_events():
         display on 'Events' page.
     """
     events = mongo.db.events.find()
-    return render_template("events.html", events=events)
+    events = events.sort("event_date")
+    now = datetime.datetime.now()
+    return render_template("events.html", events=events, now=now)
 
 
 @app.route("/new_event", methods=["GET", "POST"])
@@ -134,6 +138,8 @@ def new_event():
         event["event_owner"] = session.get("user", "")
         event["members_attending"] = []
         event["test_event"] = True
+        event["event_date"] = dateutil.parser.parse(event["event_date"])
+
         mongo.db.events.insert_one(event)
         flash(f"You have now created new event {event['event_name']}")
         return redirect("/get_events")
@@ -158,17 +164,9 @@ def attend_event(event_id):
 
 
 @app.template_filter('format_date')
-def formate_date(value):
-    if not value:
-        return "date not set"
-    dateTime = getDate(value)
-    date = dateTime["date"]
-    time = dateTime["time"]
-    return f"{date[2]}/{date[1]}/{date[0]} at {time}"
+def formate_date(value, format="%d/%m/%y at %H:%M"):
+    return value.strftime(format)
 
-def getDate(dateString):
-    dateTime = dateString.split("T")
-    return {"date": dateTime[0].split("-"), "time": dateTime[1]}
 
 if __name__ == "__main__":
     app.run(host=os.environ.get("IP"),

--- a/templates/events.html
+++ b/templates/events.html
@@ -13,6 +13,20 @@
             </div>
         </div>
         <div class="col-10 col-sm-8 col-lg-4">
+            {%if now > event.event_date %}
+            <div>
+                This event has happened!<br>
+                {%if event.members_attending|length == 1%}1 person {%else%}{{event.members_attending|length}}
+                people{%endif%} attended this event!
+            </div>
+            {%if session.user in event.members_attending%}
+            <div class="btn btn-primary btn-lg px-4 me-sm-3">You were here</div>
+            {%endif%}
+            {%else%}
+            <div>
+                {%if event.members_attending|length == 1%}1 person is{%else%}{{event.members_attending|length}} people
+                are{%endif%} attending this event!
+            </div>
             {%if not session.user %}
             <a class="btn btn-primary btn-lg px-4 me-sm-3" href="{{ url_for('login') }}">Please Log in to be able to say
                 you're coming</a>
@@ -21,6 +35,7 @@
                 want to attend this event</a>
             {%else%}
             <div>Already attending event</div>
+            {%endif%}
             {%endif%}
         </div>
     </div>

--- a/templates/events.html
+++ b/templates/events.html
@@ -1,108 +1,67 @@
 {% extends "base.html" %}
 {% block content %}
-
-
-<div class="container px-4 py-5">
-    {% for event in events %}
-    <div class="row flex-lg-row align-items-center g-5">
-        <div class="col-lg-8">
-            <h2 class="fw-bold lh-1 mb-3 text-center text-lg-start">{{ event.event_name }}</h2>
-            <p class="lead">{{ event.event_description }}</p>
-            <div class="d-grid gap-2 d-md-flex justify-content-md-start">
-                {{ event.event_place }} - {{event.event_date|format_date }}
-            </div>
-        </div>
-        <div class="col-10 col-sm-8 col-lg-4">
-            {%if now > event.event_date %}
-            <div>
-                This event has happened!<br>
-                {%if event.members_attending|length == 1%}1 person {%else%}{{event.members_attending|length}}
-                people{%endif%} attended this event!
-            </div>
-            {%if session.user in event.members_attending%}
-            <div class="btn btn-primary btn-lg px-4 me-sm-3">You were here</div>
-            {%endif%}
-            {%else%}
-            <div>
-                {%if event.members_attending|length == 1%}1 person is{%else%}{{event.members_attending|length}} people
-                are{%endif%} attending this event!
-            </div>
-            {%if not session.user %}
-            <a class="btn btn-primary btn-lg px-4 me-sm-3" href="{{ url_for('login') }}">Please Log in to be able to say
-                you're coming</a>
-            {%elif session.user not in event.members_attending%}
-            <a class="btn btn-primary btn-lg px-4 me-sm-3" href="{{ url_for('attend_event', event_id=event._id) }}">I
-                want to attend this event</a>
-            {%else%}
-            <div>Already attending event</div>
-            {%endif%}
-            {%endif%}
-        </div>
-    </div>
-    {% if not loop.last %}
-    <hr>
-    {% endif %}
-    {% endfor %}
-</div>
-
-
-
 <!-- Upcoming events / suggestion of display for Eva (to be updated or removed) -->
 
 <section class="py-5">
-    <div class="container px-5 my-5">
+    <div class="container px-5 mb-5">
         <div class="row gx-5 justify-content-center">
             <div class="col-lg-8 col-xl-6">
                 <div class="text-center">
-                    <div class="text-center">
-                        <h1 class="fw-bolder mb-5">Upcoming events</h1>
-                        <p class="lead fw-normal text-muted mb-5"> Create search function + display events</p>
-                        <form class="d-flex" action="" method="POST">
-                            <input class="form-control me-2 validate mt-5" name="query" id="query" type="search"
-                                placeholder="Search events" aria-label="Search" required>
-                            <a href="{{ url_for('get_events') }}" class="btn btn-secondary mt-5">Reset</a>
-                            <button class="btn btn-outline-light mt-5" style="color:whitesmoke"
-                                type="submit">Submit</button>
-                        </form>
-                    </div>
+                    <h1 class="fw-bolder">Upcoming events</h1>
+                    <p class="lead fw-normal text-muted"> Create search function + display events</p>
+                    <form class="d-flex" action="" method="POST">
+                        <input class="form-control me-2 validate" name="query" id="query" type="search"
+                            placeholder="Search events" aria-label="Search" required>
+                        <button class="btn btn-primary btn-outline-light" style="color:whitesmoke" type="submit">Submit</button>
+                        <a href="{{ url_for('get_events') }}" class="btn btn-secondary">Reset</a>
+                    </form>
                 </div>
             </div>
         </div>
         {% for event in events %}
-        <div class="row gx-5">
-            <div class="col-lg-4 mb-5">
-                <div class="card h-100 shadow border-0">
-                    <img class="card-img-top" src="https://dummyimage.com/600x350/ced4da/6c757d" alt="event_image" />
-                    <div class="card-body p-4">
-                        <div class="badge bg-primary bg-gradient rounded-pill mb-2">{{ event.event_place }}</div>
-                        <a class="text-decoration-none link-dark stretched-link" href="#!">
-                            <h5 class="card-title mb-3">{{ event.event_name}}</h5>
-                        </a>
-                        <p class="card-text mb-0">{{ event.event_description }}</p>
-                    </div>
-                    <div class="card-footer p-4 pt-0 bg-transparent border-top-0">
-                        <div class="d-flex align-items-end justify-content-between">
-                            <div class="d-flex align-items-center">
-                                <img class="rounded-circle me-3" src="https://dummyimage.com/40x40/ced4da/6c757d"
-                                    alt="..." />
-                                <div class="small">
-                                    <div class="text-muted">{{ event.event_date }}</div>
-                                    {%if session.user not in event.members_attending%}
-                                    <a href="{{ url_for('attend_event', event_id=event._id) }}">I want to attend this
-                                        event</a>
-                                    {%else%}
-                                    <div>Already attending event</div>
-                                    {%endif%}
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+        <div class="row flex-lg-row align-items-center g-5">
+            <div class="col-lg-8">
+                <h2 class="fw-bold lh-1 mb-3 text-center text-lg-start">{{ event.event_name }}</h2>
+                <p class="lead">{{ event.event_description }}</p>
+                <div class="d-grid gap-2 d-md-flex justify-content-md-start">
+                    {{ event.event_place }} - {{event.event_date|format_date }}
                 </div>
             </div>
+            <div class="col-10 col-sm-8 col-lg-4">
+                {%if now > event.event_date %}
+                <div>
+                    This event has happened!<br>
+                    {%if event.members_attending|length == 1%}1 person {%else%}{{event.members_attending|length}}
+                    people{%endif%} attended this event!
+                </div>
+                {%if session.user in event.members_attending%}
+                <div class="btn btn-primary btn-lg px-4 me-sm-3">You were here</div>
+                {%endif%}
+                {%else%}
+                <div>
+                    {%if event.members_attending|length == 1%}1 person is{%else%}{{event.members_attending|length}}
+                    people
+                    are{%endif%} attending this event!
+                </div>
+                {%if not session.user %}
+                <a class="btn btn-primary btn-lg px-4 me-sm-3" href="{{ url_for('login') }}">Please Log in to be able to
+                    say
+                    you're coming</a>
+                {%elif session.user not in event.members_attending%}
+                <a class="btn btn-primary btn-lg px-4 me-sm-3"
+                    href="{{ url_for('attend_event', event_id=event._id) }}">I
+                    want to attend this event</a>
+                {%else%}
+                <div>Already attending event</div>
+                {%endif%}
+                {%endif%}
+            </div>
         </div>
+        {% if not loop.last %}
+        <hr>
+        {% endif %}
         {% endfor %}
     </div>
 </section>
-
 
 {% endblock %}


### PR DESCRIPTION
Events page is now default sorted by date of the event. Currently events that happened in the past just have a change to the "join" section to instead say "this has happened"
Events can be searched, searches through name, description and place for the text typed

Events use date format instead of strings, this broke previous pages but makes them easier to work with in python